### PR TITLE
Arch patch for curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ If you dont want to downlad the very latest script, which might have bugs you ca
 To run this properly you should have Bash version 4.x and the following additional commands must be available:
 * curl (to communicate with the API)
 * sha1sum (for API signature)
+* ca-certificates-utils*
+
+**For Arch Linux only*
 
 ### Generate API keys
 In order to use this script you have to generate 3 keys for the API which are the:

--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ Ok: ns304258.ip-94-23-210.eu will expire in 19 days on 2016-09-05.
 If you dont want to downlad the very latest script, which might have bugs you can download the latest release [here](https://github.com/Decstasy/ovh-nagios-service-expiry-check/releases/latest).
 
 ### Requirements
-To run this properly you should have Bash version 4.x and the following additional commands must be available:
+To run this properly you should have Bash version 4.x and the these additional commands must be available:
 * curl (to communicate with the API)
 * sha1sum (for API signature)
-* ca-certificates-utils*
 
-**For Arch Linux only*
+The following additional packages are needed on Arch Linux:
+* ca-certificates-utils (to use curl with SSL)
 
 ### Generate API keys
 In order to use this script you have to generate 3 keys for the API which are the:

--- a/check_ovh_service_expiry.sh
+++ b/check_ovh_service_expiry.sh
@@ -81,7 +81,18 @@ function check_progs {
                         rc=1
                 fi
         done
-        [[ $rc -ge 1 ]] && exit $rc
+        # Arch Linux only
+	if [[ -f /etc/arch-release ]]; then
+		# Curl wont establish a SSL connection without ca-certificates-utils
+		# To improve performance we check for file existence and in the 2nd stage for the package via Pacman
+		if [[ ! -f /etc/ssl/certs/ca-certificates.crt ]]; then			
+			if ! pacman -Qs ca-certificates-utils >/dev/null 2>&1; then
+				echo "Package \"ca-certificates-utils\" is not installed!"
+				rc=1
+			fi
+		fi
+	fi
+	[[ $rc -ge 1 ]] && exit $rc
         true
 }
 


### PR DESCRIPTION
The package ca-certificates-utils must be installed on arch, to run curl properly with SSL.
Changed Readme and added check inside the script to handle the error.